### PR TITLE
Add zgenom instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ cd $ZSH
 git submodule add https://github.com/Ajnasz/znvm custom/plugins/znvm
 ```
 
+### Install in [zgenom](https://github.com/jandamm/zgenom)
+
+Add `zgenom load Ajnasz/znvm` in your `.zshrc` with your other `zgenom load` commands.
+
 Enable the `znvm` plugin in your `.zshrc`.
 
 [How to enable plugins in oh-my-zsh](https://github.com/ohmyzsh/ohmyzsh#plugins)


### PR DESCRIPTION
[zgenom](https://github.com/jandamm/zgenom) is the preferred framework for the [awesome-zsh-plugin](https://github.com/unixorn/awesome-zsh-plugin) list, add instructions for using it to the readme.